### PR TITLE
chore: Release 0.1.1 with repository migration notice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-06-01
+
+### Changed
+
+- Marked coinbase-samples/core-dotnet as deprecated in the README.
+- Documented migration to coinbase/core-dotnet and CoinbaseSdk.Core 0.2.0+.
+
+### Notes
+
+- No intentional API changes.
+
 ## [0.1.0] - 2025-11-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coinbase .NET Core Library
 
+The canonical source repository is **[coinbase/core-dotnet](https://github.com/coinbase/core-dotnet)**. The former [coinbase-samples/core-dotnet](https://github.com/coinbase-samples/core-dotnet) repository is deprecated. New work and releases continue on `coinbase/core-dotnet` starting with **0.2.0**. The NuGet package ID is unchanged (`CoinbaseSdk.Core`).
+
 ## Overview
 
 The **Coinbase .NET Core Library** (`CoinbaseSdk.Core`) is the foundational building block for Coinbase .NET SDKs. It provides a standardized, robust, and thread-safe infrastructure for building API clients, handling authentication, HTTP communication, and serialization.

--- a/src/CoinbaseSdk/Core/CoinbaseSdk.Core.csproj
+++ b/src/CoinbaseSdk/Core/CoinbaseSdk.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>CoinbaseSdk.Core is the core library for .NET Coinbase SDKs.</Description>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <LangVersion>12</LangVersion>
     <Authors>Coinbase</Authors>
     <TargetFrameworks>net8.0</TargetFrameworks>


### PR DESCRIPTION
Document deprecation of coinbase-samples/core-dotnet and point consumers to coinbase/core-dotnet for releases starting at 0.2.0.